### PR TITLE
fix: address an issues with merge DBs with duplicated index

### DIFF
--- a/sage/utils/supports.py
+++ b/sage/utils/supports.py
@@ -8,11 +8,11 @@ from langchain.agents.output_parsers import XMLAgentOutputParser
 from langchain.callbacks.manager import Callbacks
 from langchain.prompts import AIMessagePromptTemplate, ChatPromptTemplate
 from langchain.retrievers.document_compressors.base import BaseDocumentCompressor
-from langchain_community.docstore.base import AddableMixin
 from langchain.schema import AgentAction, AgentFinish, Document
 from langchain.schema.embeddings import Embeddings
 from langchain.tools import Tool
 from langchain_community.chat_models import ChatLiteLLM
+from langchain_community.docstore.base import AddableMixin
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_community.vectorstores.faiss import FAISS
 from litellm import aembedding, embedding


### PR DESCRIPTION
PR updates the merge_from to allow skip duplicate data during merge operations while repopulating the index